### PR TITLE
Remove `console.log`

### DIFF
--- a/src/resources/js/api/api-fetch.js
+++ b/src/resources/js/api/api-fetch.js
@@ -192,7 +192,6 @@ function matchPath (options) {
 }
 
 export default function apiFetch (options) {
-  console.log('APIFetch', options)
   return matchPath(options)
 }
 


### PR DESCRIPTION
There are a couple more console.log instances that remain, but unsure what the plan is to handle the caught promise rejections.

Fixes: #5 