### PR TITLE
Allow Overriding of Models

### DIFF
--- a/src/Http/Controllers/BlockController.php
+++ b/src/Http/Controllers/BlockController.php
@@ -1,45 +1,54 @@
-<?php
-
-namespace VanOns\Laraberg\Http\Controllers;
+<?php namespace VanOns\Laraberg\Http\Controllers;
 
 use Illuminate\Http\Request;
 
-use VanOns\Laraberg\Models\Block;
-
 class BlockController extends ApplicationController
 {
+    protected $blockModel;
+
+    public function __construct()
+    {
+        $this->blockModel = config("laraberg.models.block");
+        $this->blockModel = new $this->blockModel;
+    }
+
     public function index()
     {
-        $blocks = Block::all();
+        $blocks = $this->blockModel->all();
         return $this->ok($blocks);
     }
-    // PHP
+
     public function store(Request $request)
     {
-        $block = new Block();
+        $block = $this->blockModel;
         $block->raw_title = $request->title;
         $block->status = $request->status;
         $block->setContent($request->content);
         $block->updateSlug();
         $block->save();
+
         return $this->ok($block->toJson(), 201);
     }
 
     public function show(Request $request, $id)
     {
-        $block = Block::find($id);
+        $block = $this->blockModel->find($id);
+
         if (!$block) {
             return $this->notFound();
         }
+
         return $this->ok($block);
     }
 
     public function update(Request $request, $id)
     {
-        $block = Block::find($id);
+        $block = $this->blockModel->find($id);
+
         if (!$block) {
             return $this->notFound();
         }
+
         $block->raw_title = $request->title;
         $block->status = $request->status;
         $block->setContent($request->content);
@@ -48,14 +57,16 @@ class BlockController extends ApplicationController
         return $this->ok($block);
     }
 
-    public function destroy(Request $request, $id)
+    public function destroy($id)
     {
-        $block = Block::find($id);
-        if (!$block) {
+        $block = $this->blockModel->find($id);
+
+        if (! $block) {
             return $this->notFound();
         }
+
         $block->delete();
+
         return $this->ok();
     }
 }
-

--- a/src/config/laraberg.php
+++ b/src/config/laraberg.php
@@ -1,16 +1,24 @@
 <?php
 
+use VanOns\Laraberg\Models\Block;
+use VanOns\Laraberg\Models\Content;
+
 return [
-  /*
-  |--------------------------------------------------------------------------
-  | API Routes
-  |--------------------------------------------------------------------------
-  */
+    /*
+    |--------------------------------------------------------------------------
+    | API Routes
+    |--------------------------------------------------------------------------
+    */
 
-  'use_package_routes' => true,
+    'use_package_routes' => true,
 
-  'middlewares' => ['web', 'auth'],
+    'middlewares' => ['web', 'auth'],
 
-  'prefix' => 'laraberg'
+    'prefix' => 'laraberg',
 
+    "models" => [
+        "block" => Block::class,
+        "content" => Content::class,
+    ],
+    
 ];


### PR DESCRIPTION
This is important for multi-tenancy applications, and to resolve conflicts between packages.

### Examples
```php
<?php namespace App\Laraberg;

use Hyn\Tenancy\Traits\UsesTenantConnection;
use VanOns\Laraberg\Models\Block as LarabergBlock;

class Block extends LarabergBlock
{
    use UsesTenantConnection;
}
```

```php
<?php namespace App\Laraberg;

use Hyn\Tenancy\Traits\UsesTenantConnection;
use VanOns\Laraberg\Models\Content as LarabergContent;

class Content extends LarabergContent
{
    use UsesTenantConnection;
}
```

```php
<?php

use App\Laraberg\Block;
use App\Laraberg\Content;

return [
    /*
    |--------------------------------------------------------------------------
    | API Routes
    |--------------------------------------------------------------------------
    */

    'use_package_routes' => true,

    'middlewares' => ['web', 'auth'],

    'prefix' => 'laraberg',

    "models" => [
        "block" => Block::class,
        "content" => Content::class,
    ],

];
```

