### PR TITLE
Fixes wrong relation name when deleting

### DIFF
--- a/src/Models/Gutenbergable.php
+++ b/src/Models/Gutenbergable.php
@@ -62,7 +62,7 @@ trait Gutenbergable
     protected static function bootGutenbergable()
     {   
         self::deleting(function ($model) {
-            $model->content()->delete();
+            $model->laraberg_content()->delete();
         });
     }
 


### PR DESCRIPTION
It was throwing an exception as `content` relation does not exist.