### PR TITLE
Prevent saving content in lb_contents if parent model was not saved

### DIFF
--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -3,10 +3,10 @@
 namespace VanOns\Laraberg\Models;
 
 use Illuminate\Database\Eloquent\Model;
-
 use VanOns\Laraberg\Helpers\EmbedHelper;
 use VanOns\Laraberg\Helpers\BlockHelper;
 use VanOns\Laraberg\Events\ContentCreated;
+use VanOns\Laraberg\Events\ContentUpdated;
 use VanOns\Laraberg\Events\ContentRendered;
 
 class Content extends Model

--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -4,14 +4,28 @@ namespace VanOns\Laraberg\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-use VanOns\Laraberg\Events\ContentRendered;
-use VanOns\Laraberg\Helpers\BlockHelper;
 use VanOns\Laraberg\Helpers\EmbedHelper;
+use VanOns\Laraberg\Helpers\BlockHelper;
+use VanOns\Laraberg\Events\ContentCreated;
+use VanOns\Laraberg\Events\ContentRendered;
 
 class Content extends Model
 {
 
     protected $table = 'lb_contents';
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::created(function ($model) {
+            event(new ContentCreated($model));
+        });
+
+        static::updated(function ($model) {
+            event(new ContentUpdated($model));
+        });
+    }
 
     public function contentable()
     {
@@ -25,6 +39,9 @@ class Content extends Model
     public function render()
     {
         $html = BlockHelper::renderBlocks($this->rendered_content);
+
+        event(new ContentRendered($this));
+
         return "<div class='gutenberg__content wp-embed-responsive'>$html</div>";
     }
 
@@ -35,6 +52,7 @@ class Content extends Model
     public function setContent($html)
     {
         $this->raw_content = $html;
+
         $this->renderRaw();
     }
 
@@ -44,7 +62,9 @@ class Content extends Model
     public function renderRaw()
     {
         $this->rendered_content = EmbedHelper::renderEmbeds($this->raw_content);
+
         event(new ContentRendered($this));
+
         return $this->rendered_content;
     }
 }

--- a/src/Models/Gutenbergable.php
+++ b/src/Models/Gutenbergable.php
@@ -15,7 +15,10 @@ trait Gutenbergable
     {
         // Persisting laraberg contents only when the current model has been updated
         self::saved(function ($model) {
-            $model->larabergContent->save();
+            if ($content = $model->larabergContent) {
+                $content->contentable()
+                        ->associate($model)->save();
+            }
         });
 
         // Permanently deleting laravel content when this model has been deleted
@@ -46,7 +49,7 @@ trait Gutenbergable
 
     /**
      * Set the laraberg content.
-     * 
+     *
      * @param $content
      */
     public function setLbContentAttribute($content)
@@ -73,8 +76,8 @@ trait Gutenbergable
     /**
      * Returns the raw content that came out of Gutenberg
      *
-     * @deprecated
      * @return String
+     * @deprecated
      */
     public function getRawContent()
     {
@@ -84,8 +87,8 @@ trait Gutenbergable
     /**
      * Returns the Gutenberg content with some initial rendering done to it
      *
-     * @deprecated
      * @return String
+     * @deprecated
      */
     public function getRenderedContent()
     {
@@ -95,9 +98,9 @@ trait Gutenbergable
     /**
      * Sets the content object using the raw editor content
      *
-     * @deprecated
      * @param String $content
      * @param String $save - Calls .save() on the Content object if true
+     * @deprecated
      */
     public function setContent($content, $save = false)
     {


### PR DESCRIPTION
Content class improvements:
- Added event dispatching to the model. This model is now able to detect if has been created/updated and fire the right event.

Gutenbergable trait improvements:
- Removed `save` method from `set` accessors and `get` mutators. This method is now fired when the parent model is saved (important!).
- Replaced `deleting` event by `deleted`. This will make sure we destroy the record if the parent model has been truly deleted.
- Refactored method names to follow the Laravel convention names.
- Fixed issue when deleting, it was calling a `content` relation rather than `larabergConntent`, which was causing an error.


Open to edits and changes!

Issue #49 