### PR TITLE
Allow for configurable table names in the migrations

### DIFF
--- a/src/Models/Block.php
+++ b/src/Models/Block.php
@@ -23,6 +23,14 @@ class Block extends Model
     // TODO: Only here to make migration run, should be cleaned up on release
     protected $casts = ['old_title' => 'array'];
 
+	/**
+	 * Returns table name statically to use in migrations
+	 */
+	public static function tableName()
+	{
+		return with(new static)->getTable();
+	}
+
     /**
      * Updates slug according to title
      */

--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -12,8 +12,15 @@ use VanOns\Laraberg\Events\ContentRendered;
 
 class Content extends Model
 {
-
     protected $table = 'lb_contents';
+
+	/**
+	 * Returns table name statically to use in migrations
+	 */
+	public static function tableName()
+	{
+		return with(new static)->getTable();
+	}
 
     public static function boot()
     {

--- a/src/database/migrations/2019_02_08_105647_create_blocks_contents_tables.php
+++ b/src/database/migrations/2019_02_08_105647_create_blocks_contents_tables.php
@@ -13,7 +13,7 @@ class CreateBlocksContentsTables extends Migration
      */
     public function up()
     {
-        Schema::create('lb_blocks', function (Blueprint $table) {
+        Schema::create(config('laraberg.models.block', \VanOns\Laraberg\Models\Block::class)::tableName(), function (Blueprint $table) {
             $table->increments('id');
             $table->string('raw_title')->nullable();
             $table->text('raw_content')->nullable();
@@ -24,7 +24,7 @@ class CreateBlocksContentsTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create('lb_contents', function (Blueprint $table) {
+        Schema::create(config('laraberg.models.content', \VanOns\Laraberg\Models\Content::class)::tableName(), function (Blueprint $table) {
             $table->increments('id');
             $table->text('raw_content')->nullable();
             $table->text('rendered_content')->nullable();
@@ -41,8 +41,8 @@ class CreateBlocksContentsTables extends Migration
      */
     public function down()
     {
-        Schema::drop('lb_blocks');
-        Schema::drop('lb_contents');
+        Schema::drop(config('laraberg.models.block', \VanOns\Laraberg\Models\Block::class)::tableName());
+        Schema::drop(config('laraberg.models.content', \VanOns\Laraberg\Models\Content::class)::tableName());
     }
 }
 


### PR DESCRIPTION
Migrations will use the original table name from the package models unless configured differently using the configuration file.

Creating your own models, and override the table name:

```
<?php

namespace App\Models\Laraberg;

use VanOns\Laraberg\Models\Block as LarabergBlock;

class Block extends LarabergBlock
{
	protected $table = 'laraberg_blocks';
}
```

```
<?php

namespace App\Models\Laraberg;

use VanOns\Laraberg\Models\Content as LarabergContent;

class Content extends LarabergContent
{
	protected $table = 'laraberg_content';
}
```

Then under the laraberg.php configuration file (once published), you can reference your own models:

```
<?php

use App\Models\Laraberg\Block;
use App\Models\Laraberg\Content;

return [
	'use_package_routes' => true,

	'middlewares' => ['web', 'auth'],

	'prefix' => 'laraberg',

	'models' => [
		'block' => Block::class,
		'content' => Content::class,
	],
];
```

When running `php artisan migrate` it'll create tables using your specified table names instead.