### PR TITLE
Merge default config for Laraberg

### DIFF
--- a/src/LarabergServiceProvider.php
+++ b/src/LarabergServiceProvider.php
@@ -25,6 +25,8 @@ class LarabergServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/config/laraberg.php', 'laraberg');
+        
         $this->app->singleton(Laraberg::class, function () {
             return new Laraberg();
         });


### PR DESCRIPTION
Adding this `mergeConfig` call makes sure that any changes to the package's config file are being merged with the application's local config file (if there is one).

When adding new config keys in the package, users will no longer have manually update their local config files as these default changes will be merged automatically.

More info here: https://laravel.com/docs/master/packages#default-package-configuration