### PR TITLE
[Fix] Use builtin route registration to allow caching

### DIFF
--- a/src/LarabergServiceProvider.php
+++ b/src/LarabergServiceProvider.php
@@ -22,8 +22,8 @@ class LarabergServiceProvider extends ServiceProvider
         $this->publishes([__DIR__ . '/../public' => public_path('vendor/laraberg')], 'public');
 
         if (config('laraberg.use_package_routes')) {
-            require_once __DIR__ . '/Http/routes.php';
-        };
+            $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');
+        }
 
         require_once __DIR__ . '/Blocks/wp.php';
     }


### PR DESCRIPTION
This PR changes the package's route registration to use `->loadRoutesFrom()`, which allows the caching of these routes.