### PR TITLE
Fix embed

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -66,7 +66,7 @@ class Block
             $output = call_user_func($blockType->renderCallback, $this->attributes, $output, $this);
         }
 
-        if ($this->blockName === 'core/embed') {
+        if (strpos($this->blockName, 'embed') !== false) {
             $output = $this->embed($output);
         }
 


### PR DESCRIPTION
There is a problem rendering youtube embeds (I imagine others too)
<img width="1037" alt="Screen Shot 2022-10-25 at 12 33 34 AM" src="https://user-images.githubusercontent.com/57962651/197691094-136af1a5-8b35-4fbf-8c38-0a08cfb936a0.png">

The problem is that the variable $this->blockName === 'core-embed' is being compared but now it seems to be called 'core-embed/youtube'
<img width="1284" alt="Screen Shot 2022-10-25 at 12 28 37 AM" src="https://user-images.githubusercontent.com/57962651/197691302-65de6832-0375-444b-ac14-28b05a0ca631.png">

the solution is to use strpos to check if the word embed exists
<img width="516" alt="Screen Shot 2022-10-25 at 12 32 45 AM" src="https://user-images.githubusercontent.com/57962651/197691426-b10c4ae9-d32d-4da6-acd5-e045573aba09.png">

this is the result
<img width="926" alt="Screen Shot 2022-10-25 at 12 34 05 AM" src="https://user-images.githubusercontent.com/57962651/197691459-a1b4f541-d670-4096-8b42-d7e6111a013f.png">


