### PR TITLE
[Fix] Prevent fetching if endpoint was not found

### DIFF
--- a/src/Services/OEmbedService.php
+++ b/src/Services/OEmbedService.php
@@ -27,8 +27,13 @@ class OEmbedService
             return $cached;
         }
 
+        $endpoint = $this->getEndpointUrl($url);
+        if ($endpoint === null) {
+            return null;
+        }
+
         $data = $this->fetch(
-            $this->getEndpointUrl($url),
+            $endpoint,
             compact('url')
         );
 


### PR DESCRIPTION
Implemented a fix for the following exception:

```
VanOns\Laraberg\Services\OEmbedService::fetch(): Argument #1 ($url) must be of type string, null given, called in /<redacted>/vendor/van-ons/laraberg/src/Services/OEmbedService.php on line 32
```